### PR TITLE
Add multiple recipients post "errors"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.idea
 /vendor
 /composer.lock
-
+/.phpunit.result.cache

--- a/src/CreateRecipientsResponseErrorNormalizer.php
+++ b/src/CreateRecipientsResponseErrorNormalizer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linkage\SendgridMarketingCampaignApiClient;
+
+use Linkage\SendgridMarketingCampaignApiClient\Recipients\CreateRecipientsResponseError;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class CreateRecipientsResponseErrorNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            CreateRecipientsResponseError::class => true,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return array{message: string, error_indices: array<int>}
+     */
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    {
+        if (!$object instanceof CreateRecipientsResponseError) {
+            throw new InvalidArgumentException('The object must be an instance of "CreateRecipientsResponseError".');
+        }
+
+        return [
+            'message' => $object->message,
+            'error_indices' => $object->errorIndices,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof CreateRecipientsResponseError;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        if ($data === null) {
+            return null;
+        }
+        if ($type !== CreateRecipientsResponseError::class) {
+            throw new InvalidArgumentException('type must be CreateRecipientsResponseError.');
+        }
+
+        if (!\is_array($data) || !isset($data['message']) || !isset($data['error_indices'])) {
+            throw new InvalidArgumentException('type must be CreateRecipientsResponseError.');
+        }
+
+        return new CreateRecipientsResponseError(
+            message: $data['message'],
+            errorIndices: $data['error_indices'],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === CreateRecipientsResponseError::class;
+    }
+}

--- a/src/Recipients/CreateRecipientsResponse.php
+++ b/src/Recipients/CreateRecipientsResponse.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Linkage\SendgridMarketingCampaignApiClient\Recipients;
 
-readonly class CreateRecipientsResponse
+class CreateRecipientsResponse
 {
     /**
      * @param array<int>    $errorIndices
      * @param array<int>    $unmodifiedIndices
      * @param array<string> $persistedRecipients
+     * @param array<CreateRecipientsResponseError|array<array{message: string, error_indices: array<int>}> $errors
      */
     public function __construct(
         public int $errorCount,
@@ -18,6 +19,23 @@ readonly class CreateRecipientsResponse
         public int $newCount,
         public array $persistedRecipients,
         public int $updatedCount,
+        public array $errors,
     ) {
+    }
+
+    /**
+     * @param array<CreateRecipientsResponseError> $errors
+     */
+    public function setErrors(array $errors): void
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * @return array<array{message: string, error_indices: array<int>}>|array<CreateRecipientsResponseError>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
     }
 }

--- a/src/Recipients/CreateRecipientsResponseError.php
+++ b/src/Recipients/CreateRecipientsResponseError.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linkage\SendgridMarketingCampaignApiClient\Recipients;
+
+class CreateRecipientsResponseError
+{
+    public function __construct(
+        public string $message,
+        /** @var array<int> $errorIndices */
+        public array $errorIndices,
+    ) {
+    }
+}

--- a/tests/CreateRecipientsResponseErrorNormalizerTest.php
+++ b/tests/CreateRecipientsResponseErrorNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linkage\SendgridMarketingCampaignApiClient\Tests;
+
+use Linkage\SendgridMarketingCampaignApiClient\CreateRecipientsResponseErrorNormalizer;
+use Linkage\SendgridMarketingCampaignApiClient\Recipients\CreateRecipientsResponseError;
+use PHPUnit\Framework\TestCase;
+
+class CreateRecipientsResponseErrorNormalizerTest extends TestCase
+{
+    private CreateRecipientsResponseErrorNormalizer $SUT;
+
+    protected function setUp(): void
+    {
+        $this->SUT = new CreateRecipientsResponseErrorNormalizer();
+    }
+
+    public function testSupportsNormalization(): void
+    {
+        $this->assertTrue($this->SUT->supportsNormalization(new CreateRecipientsResponseError('foo', [1])));
+        $this->assertFalse($this->SUT->supportsNormalization('string-value'));
+        $this->assertFalse($this->SUT->supportsNormalization(new \stdClass()));
+    }
+
+    public function testNormalize(): void
+    {
+        $actual = $this->SUT->normalize(new CreateRecipientsResponseError('foo', [1, 3]));
+
+        $this->assertIsArray($actual);
+        $this->assertArrayHasKey('message', $actual);
+        $this->assertArrayHasKey('message', $actual);
+        $this->assertSame('foo', $actual['message']);
+        $this->assertIsArray($actual['error_indices']);
+        $this->assertCount(2, $actual['error_indices']);
+        $this->assertSame(1, $actual['error_indices'][0]);
+        $this->assertSame(3, $actual['error_indices'][1]);
+    }
+
+    public function testDenormalize(): void
+    {
+        $actual = $this->SUT->denormalize([
+            'message' => 'foo',
+            'error_indices' => [1, 3],
+        ], CreateRecipientsResponseError::class);
+
+        $this->assertInstanceOf(CreateRecipientsResponseError::class, $actual);
+        $this->assertSame('foo', $actual->message);
+        $this->assertIsArray($actual->errorIndices);
+        $this->assertCount(2, $actual->errorIndices);
+        $this->assertSame(1, $actual->errorIndices[0]);
+        $this->assertSame(3, $actual->errorIndices[1]);
+    }
+}

--- a/tests/SendgridApiRequesterTest.php
+++ b/tests/SendgridApiRequesterTest.php
@@ -11,6 +11,10 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Linkage\SendgridMarketingCampaignApiClient\ContactList\CreateContactListRequest;
 use Linkage\SendgridMarketingCampaignApiClient\ContactList\CreateContactListResponse;
+use Linkage\SendgridMarketingCampaignApiClient\Recipients\CreateRecipientsRequest;
+use Linkage\SendgridMarketingCampaignApiClient\Recipients\CreateRecipientsResponse;
+use Linkage\SendgridMarketingCampaignApiClient\Recipients\CreateRecipientsResponseError;
+use Linkage\SendgridMarketingCampaignApiClient\Recipients\RecipientRequest;
 use Linkage\SendgridMarketingCampaignApiClient\SendgridApiClientException;
 use Linkage\SendgridMarketingCampaignApiClient\SendgridApiRequester;
 use Linkage\SendgridMarketingCampaignApiClient\SendgridApiServerException;
@@ -26,7 +30,7 @@ class SendgridApiRequesterTest extends TestCase
         $this->guzzleClientMock = $this->createMock(ClientInterface::class);
     }
 
-    public function testPost(): void
+    public function testPostContactList(): void
     {
         $this->guzzleClientMock->expects($this->once())
             ->method('request')
@@ -47,6 +51,60 @@ class SendgridApiRequesterTest extends TestCase
         $this->assertSame(1, $actual->id);
         $this->assertSame('dummy-name', $actual->name);
         $this->assertSame(0, $actual->recipientCount);
+    }
+
+    public function testPostMultipleRecipients(): void
+    {
+        $json = <<<'EOJ'
+                {
+                  "error_count": 1,
+                  "error_indices": [
+                    2
+                  ],
+                  "unmodified_indices": [
+                    3
+                  ],
+                  "new_count": 2,
+                  "persisted_recipients": [
+                    "YUBh",
+                    "bWlsbGVyQG1pbGxlci50ZXN0"
+                  ],
+                  "updated_count": 0,
+                  "errors": [
+                    {
+                      "message": "Invalid email.",
+                      "error_indices": [
+                        2
+                      ]
+                    }
+                  ]
+                }
+            EOJ;
+        $this->guzzleClientMock->expects($this->once())
+            ->method('request')
+            ->with('POST', '/dummy/path', [
+                'body' => '[{"email":"example@example.com"},{"email":"eexampexample@example.com"},{"email":"invalid_email"}]',
+            ])
+            ->willReturn(new Response(body: $json))
+        ;
+
+        /** @var CreateRecipientsResponse $actual */
+        $actual = $this->getSUT()->post(
+            '/dummy/path',
+            new CreateRecipientsRequest([
+                new RecipientRequest(email: 'example@example.com'),
+                new RecipientRequest(email: 'eexampexample@example.com'),
+                new RecipientRequest(email: 'invalid_email'),
+            ]),
+            CreateRecipientsResponse::class,
+        );
+
+        $this->assertInstanceOf(CreateRecipientsResponse::class, $actual);
+        $this->assertIsArray($actual->errors);
+        $this->assertCount(1, $actual->errors);
+        $this->assertInstanceOf(CreateRecipientsResponseError::class, $actual->errors[0]);
+        $this->assertSame('Invalid email.', $actual->errors[0]->message);
+        $this->assertSame([2], $actual->errors[0]->errorIndices);
     }
 
     public function testPostClientError(): void


### PR DESCRIPTION
- 後方互換性の無い変更です
- 本来は配列要素のクラスへの変換を自動で行うべきですが、実装方法がわからなかったので自前で事後処理をはさんでクラスに変換しました
  - この実装にしたため、 `SerializeFactory` は変更していません
- `SendgridApiRequester` のコンストラクタ引数がアプリケーション側で指定必須に変わります
  - nullable にしてクライアントライブラリ側で生成するか迷いました