### PR TITLE
updated static-analysis-kit version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,11 +49,5 @@
         "fix:rector": "Tries to fix code in this project automatically with rector enabled.",
         "fix:risky": "Tries to fix code in this project automatically with risky rules.",
         "test": "Runs the tests."
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/77web/quartetcom-static-analysis-kit.git"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4",
-        "quartetcom/static-analysis-kit": "^8.2"
+        "quartetcom/static-analysis-kit": "8.2.x-dev"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4",
-        "quartetcom/static-analysis-kit": "dev-fix/rector-deprecation@dev"
+        "quartetcom/static-analysis-kit": "^8.2"
     },
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
```
$ composer install
No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
Loading composer repositories with package information                                                                                                                                                                                                       Updating dependencies                                 
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires quartetcom/static-analysis-kit dev-fix/rector-deprecation@dev, found quartetcom/static-analysis-kit[8.2.x-dev] but it does not match the constraint.
 ```